### PR TITLE
Normalize and absolutize paths before comparing them

### DIFF
--- a/src/main/java/com/google/devtools/build/bfg/JavaSourceFileParser.java
+++ b/src/main/java/com/google/devtools/build/bfg/JavaSourceFileParser.java
@@ -15,6 +15,8 @@
 package com.google.devtools.build.bfg;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.getLast;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -60,13 +62,21 @@ public class JavaSourceFileParser {
    *     instead of one-rule-per-file. See {@link #oneRulePerPackageRoots}.
    */
   JavaSourceFileParser(
-      ImmutableList<Path> absoluteSourceFilePaths,
+      ImmutableList<Path> sourceFilePaths,
       ImmutableList<Path> contentRoots,
       ImmutableSet<Path> oneRulePerPackageRoots)
       throws IOException {
-    this.absoluteSourceFilePaths = absoluteSourceFilePaths;
+    this.absoluteSourceFilePaths =
+        sourceFilePaths
+            .stream()
+            .map(p -> p.toAbsolutePath().normalize())
+            .collect(toImmutableList());
     this.contentRoots = contentRoots;
-    this.oneRulePerPackageRoots = oneRulePerPackageRoots;
+    this.oneRulePerPackageRoots =
+        oneRulePerPackageRoots
+            .stream()
+            .map(p -> p.toAbsolutePath().normalize())
+            .collect(toImmutableSet());
     unresolvedClassNames = new HashSet<>();
     classDependencyGraph = createClassDependencyGraph();
   }

--- a/src/test/java/com/google/devtools/build/bfg/JavaSourceFileParserTest.java
+++ b/src/test/java/com/google/devtools/build/bfg/JavaSourceFileParserTest.java
@@ -244,14 +244,14 @@ public class JavaSourceFileParserTest {
     JavaSourceFileParser parser =
         new JavaSourceFileParser(
             ImmutableList.of(
-                workspace.resolve("x/A.java"),
-                workspace.resolve("y/A.java"),
-                workspace.resolve("y/B.java"),
-                workspace.resolve("z/A.java"),
-                workspace.resolve("z/B.java"),
-                workspace.resolve("z/C.java"),
-                workspace.resolve("tests/A.java"),
-                workspace.resolve("tests/B.java")),
+                workspace.resolve("./x/A.java"),
+                workspace.resolve("./y/A.java"),
+                workspace.resolve("./y/B.java"),
+                workspace.resolve("./z/A.java"),
+                workspace.resolve("./z/B.java"),
+                workspace.resolve("./z/C.java"),
+                workspace.resolve("./tests/A.java"),
+                workspace.resolve("./tests/B.java")),
             contentRoots,
             ImmutableSet.of(x, y, z) /* oneRulePerPackageRoots */);
     ImmutableGraph<String> actual = parser.getClassDependencyGraph();


### PR DESCRIPTION
This fixes a case where calling JavasourceFileParser with the result of
`find .` would result in ignoring `--one_rule_per_package_roots`, because one kind of path would include ./ and the other would not.