### PR TITLE
Return class→file and file→kind from Parser

### DIFF
--- a/src/main/java/com/google/devtools/build/bfg/BUILD
+++ b/src/main/java/com/google/devtools/build/bfg/BUILD
@@ -112,6 +112,7 @@ java_library(
         ":bfg_java_proto",
         "//thirdparty/jvm/args4j",
         "//thirdparty/jvm/com/google/guava",
+        "//thirdparty/jvm/org/eclipse/jdt:org_eclipse_jdt_core",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/bfg/JavaSourceFileParser.java
+++ b/src/main/java/com/google/devtools/build/bfg/JavaSourceFileParser.java
@@ -43,9 +43,7 @@ import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
-import org.eclipse.jdt.core.dom.Type;
 
-import javax.naming.directory.Attribute;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;

--- a/src/main/java/com/google/devtools/build/bfg/ReferencedClassesParser.java
+++ b/src/main/java/com/google/devtools/build/bfg/ReferencedClassesParser.java
@@ -115,6 +115,8 @@ public class ReferencedClassesParser {
    */
   public final ImmutableSet<QualifiedName> qualifiedTopLevelNames;
 
+  public final CompilationUnit compilationUnit;
+
   public ReferencedClassesParser(String filename, String source, Collection<Path> contentRoots) {
     this.compilationMessages = getCompilationMessages(filename, source);
     if (!compilationMessages.isEmpty()) {
@@ -126,10 +128,11 @@ public class ReferencedClassesParser {
       this.superclass = "";
       this.unresolvedClassNames = ImmutableSet.of();
       this.qualifiedTopLevelNames = ImmutableSet.of();
+      this.compilationUnit = null;
       isSuccessful = false;
       return;
     }
-    CompilationUnit compilationUnit = parseAndResolveSource(source);
+    this.compilationUnit = parseAndResolveSource(source);
 
     Visitor visitor = new Visitor(compilationUnit);
     compilationUnit.accept(visitor);

--- a/src/main/java/com/google/devtools/build/bfg/bfg.proto
+++ b/src/main/java/com/google/devtools/build/bfg/bfg.proto
@@ -12,6 +12,14 @@ message ParserOutput {
     // [1] - By mention, we mean either imports or references in code, either as a fully qualified
     //       name, or an implied same-package name.
     map<string, Strings> class_to_class = 1;
+
+    // Maps a class name to the file that defines it.
+    // Paths are expected to be absolute.
+    map<string, Strings> class_to_file = 2;
+
+    // Maps a file name to the Bazel rule kind (e.g., java_library) that should be used to build it.
+    // Paths are expected to be absolute.
+    map<string, Strings> file_to_rule_kind = 3;
 }
 
 message Strings {


### PR DESCRIPTION
and change the BFG ↔ Parser protocol.

Class → file is useful for languages that don't have a 1:1 relation between class names and the location they're defined at (e.g., Scala, Kotlin).

file → kind is necessary to make BFG language-agnostic enough to support JVM languages other than Java.