### PR TITLE
Remove the manual autovalue support

### DIFF
--- a/dev-scripts/dependencies/setup.sh
+++ b/dev-scripts/dependencies/setup.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
 BAZEL_DEPS_DIR="$ROOT_DIR/../bazel-deps"
 # Pin a specific version of bazel-deps; change this to upgrade:
-BAZEL_DEPS_VERSION="7d89b39e8b9c1a0b5a1481909c56c39d970e59b1"
+BAZEL_DEPS_VERSION="aad33e40cd2ce2400347e5db28b767e5d512a4fd"
 
 if [ -d "$BAZEL_DEPS_DIR" ]
 then
@@ -37,13 +37,6 @@ generate_and_format() {
     # "$BAZEL_DEPS_DIR/gen_maven_deps.sh" format-deps --deps "$ROOT_DIR/maven_deps.yaml" --overwrite
 
     "$BAZEL_DEPS_DIR/gen_maven_deps.sh" generate --repo-root "$ROOT_DIR" --sha-file "thirdparty/workspace.bzl" --deps maven_deps.yaml
-
-    # TODO(https://github.com/johnynek/bazel-deps/issues/62): Drop once issue is fixed.
-    # Manually add the AutoValue plugin. Otherwise, everything can be auto-generated from the YAML.
-    buildozer 'add exported_plugins :auto_value_plugin' //thirdparty/jvm/com/google/auto/value:auto_value
-    buildozer 'new java_plugin auto_value_plugin' //thirdparty/jvm/com/google/auto/value:auto_value
-    buildozer 'set processor_class com.google.auto.value.processor.AutoValueProcessor' //thirdparty/jvm/com/google/auto/value:auto_value_plugin
-    buildozer 'add deps //external:jar/com/google/auto/value/auto_value' //thirdparty/jvm/com/google/auto/value:auto_value_plugin
 
     # TODO(https://github.com/johnynek/bazel-deps/issues/73): Drop once issue is fixed.
     # The generated BUILD files are not well-formatted. Run the buildifier on them.

--- a/maven_deps.yaml
+++ b/maven_deps.yaml
@@ -62,6 +62,7 @@ dependencies:
     auto-value:
       version: "1.5"
       lang: java
+      processorClasses: ["com.google.auto.value.processor.AutoValueProcessor"]
 
   com.google.code.findbugs:
     jsr305:

--- a/thirdparty/jvm/com/google/auto/value/BUILD
+++ b/thirdparty/jvm/com/google/auto/value/BUILD
@@ -1,6 +1,8 @@
 java_library(
     name = "auto_value",
-    exported_plugins = [":auto_value_plugin"],
+    exported_plugins = [
+        ":auto_value_plugin",
+    ],
     visibility = [
         "//visibility:public",
     ],
@@ -12,5 +14,10 @@ java_library(
 java_plugin(
     name = "auto_value_plugin",
     processor_class = "com.google.auto.value.processor.AutoValueProcessor",
-    deps = ["//external:jar/com/google/auto/value/auto_value"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//external:jar/com/google/auto/value/auto_value",
+    ],
 )


### PR DESCRIPTION
Now that bazel-deps supports annotation processors we can remove the buildozer rules we were using to work around this. The PR for https://github.com/johnynek/bazel-deps/issues/62 has been merged.