### PR TITLE
[WIP] Create and end-to-end test of the Java lang parser and BFG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ BUILD File Generator generates Bazel BUILD files for Java code.
 
 TODO
 
+## Decoding Language-Specific Parser Output
+
+```bash
+protoc --decode com.google.devtools.build.bfg.ParserOutput src/main/java/com/google/devtools/build/bfg/bfg.proto < ${LANG_SPECIFIC_PARSER_OUTPUT_FILE}
+```
+
 ## Adding or updating third-party dependencies
 
 We use a third-party tool called [bazel-deps](https://github.com/johnynek/bazel-deps)

--- a/e2e/java/helloworld/src/main/java/com/google/devtools/build/bfg/example/helloworld/HelloWorld.java
+++ b/e2e/java/helloworld/src/main/java/com/google/devtools/build/bfg/example/helloworld/HelloWorld.java
@@ -1,0 +1,21 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.bfg.example.helloworld;
+
+public class HelloWorld {
+  public static void main(String[] args) {
+    System.out.println("Hello, world!");
+  }
+}

--- a/e2e_java_helloworld.sh
+++ b/e2e_java_helloworld.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Generate BUILD files for the Java files in e2e/java/helloworld/
+
+set -euo pipefail
+
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+helloworld_dir="${SCRIPT_DIR}/e2e/java/helloworld"
+
+function cleanup() {
+  for file in "${helloworld_dir}/WORKSPACE" "${helloworld_dir}/src/main/java/com/google/devtools/build/bfg/example/helloworld/BUILD"; do
+    test -f "${file}" && rm "${file}"
+  done
+}
+
+java_files=($(find "${helloworld_dir}" -name *.java | xargs realpath))
+java_digraph_file=$(mktemp --suffix=.ParserOutput.bin)
+
+touch "${helloworld_dir}"/WORKSPACE
+trap cleanup EXIT
+
+# Run the language-specific parser for Java
+cd "${SCRIPT_DIR}"
+bazel build //lang/java/src/main/java/com/google/devtools/build/bfg:JavaSourceFileParserCli
+${SCRIPT_DIR}/bazel-bin/lang/java/src/main/java/com/google/devtools/build/bfg/JavaSourceFileParserCli \
+ --roots "${helloworld_dir}"/src/main/java \
+ --one_rule_per_package_roots "${helloworld_dir}"/src/main/java \
+  "$(join_by , ${java_files[@]})" > "${java_digraph_file}"
+
+# Run the BFG
+bazel build //src/main/java/com/google/devtools/build/bfg:bfg
+cd "${helloworld_dir}"
+greeting=$(${SCRIPT_DIR}/bazel-bin/src/main/java/com/google/devtools/build/bfg/bfg \
+  --workspace "${helloworld_dir}" \
+  --buildozer buildozer \
+  --whitelist "com.google.devtools.build.bfg.example.helloworld.*" < "${java_digraph_file}")
+
+cd "${SCRIPT_DIR}"
+greeting=$(bazel run //e2e/java/helloworld/src/main/java/com/google/devtools/build/bfg/example/helloworld:HelloWorld)
+test "${greeting}" == "Hello, world!"

--- a/lang/java/src/main/java/com/google/devtools/build/bfg/BUILD
+++ b/lang/java/src/main/java/com/google/devtools/build/bfg/BUILD
@@ -24,8 +24,9 @@ java_library(
         "JavaSourceFileParserCli.java",
     ],
     deps = [
-        ":ReferencedClassesParser",
+        ":ReferencedClassesParser",        
         "//src/main/java/com/google/devtools/build/bfg:bfg_java_proto",
+        "//src/main/java/com/google/devtools/build/bfg:TargetInfoUtilities",        
         "//thirdparty/jvm/args4j",
         "//thirdparty/jvm/com/google/guava",
         "//thirdparty/jvm/org/eclipse/jdt:org_eclipse_jdt_core",

--- a/lang/java/src/main/java/com/google/devtools/build/bfg/JavaSourceFileParserCli.java
+++ b/lang/java/src/main/java/com/google/devtools/build/bfg/JavaSourceFileParserCli.java
@@ -126,7 +126,7 @@ public class JavaSourceFileParserCli {
                     classname, Bfg.Strings.newBuilder().addElements(filename).build()));
 
     // fileToRuleKind
-    result.putAllFileToRuleKind(parser.getFilesToRuleKind());
+    result.putAllFileToTargetInfo(parser.getFileToTargetInfo());
     return result.build();
   }
 }

--- a/lang/java/src/test/java/com/google/devtools/build/bfg/BUILD
+++ b/lang/java/src/test/java/com/google/devtools/build/bfg/BUILD
@@ -20,6 +20,7 @@ java_test(
     deps = [
         "//lang/java/src/main/java/com/google/devtools/build/bfg:JavaSourceFileParser",
         "//lang/java/src/main/java/com/google/devtools/build/bfg:ReferencedClassesParser",
+        "//src/main/java/com/google/devtools/build/bfg:TargetInfoUtilities",
         "//thirdparty/jvm/com/google/guava",
         "//thirdparty/jvm/com/google/jimfs",
         "//thirdparty/jvm/com/google/truth",

--- a/lang/java/src/test/java/com/google/devtools/build/bfg/JavaSourceFileParserTest.java
+++ b/lang/java/src/test/java/com/google/devtools/build/bfg/JavaSourceFileParserTest.java
@@ -92,12 +92,12 @@ public class JavaSourceFileParserTest {
             "com.hello.ClassA",
             "/src/com/hello/ClassA.java");
 
-    assertThat(parser.getFilesToRuleKind())
+    assertThat(parser.getFileToTargetInfo())
         .containsExactly(
             "/src/com/hello/Dummy.java",
-            "java_library",
+            TargetInfoUtilities.javaLibrary(),
             "/src/com/hello/ClassA.java",
-            "java_library");
+            TargetInfoUtilities.javaLibrary());
   }
 
   @Test
@@ -172,6 +172,7 @@ public class JavaSourceFileParserTest {
 
     ImmutableGraph<String> actual = parser.getClassToClass();
     MutableGraph<String> expected = newGraph();
+    expected.addNode("Dummy");
 
     assertThatGraphsEqual(actual, expected);
     assertThat(parser.getUnresolvedClassNames()).containsExactly("Foo");
@@ -271,11 +272,15 @@ public class JavaSourceFileParserTest {
     ImmutableGraph<String> actual = parser.getClassToClass();
 
     MutableGraph<String> expected = newGraph();
+    expected.addNode("x.A");
     expected.putEdge("y.A", "y.B");
     expected.putEdge("y.B", "y.A");
     expected.putEdge("z.A", "z.B");
     expected.putEdge("z.B", "z.C");
     expected.putEdge("z.C", "z.A");
+    expected.addNode("tests.A");
+    expected.addNode("tests.B");
+
     // Implicit: there's no tests.A and tests.B here, because 'tests/' is not in
     // oneRulePerPackageRoots.
 
@@ -319,16 +324,16 @@ public class JavaSourceFileParserTest {
             "}");
     JavaSourceFileParser parser = createParser(file1, file2, file3);
 
-    assertThat(parser.getFilesToRuleKind())
+    assertThat(parser.getFileToTargetInfo())
         .containsExactly(
             // Binary.java has a static method named 'main' with a single String[] parameter.
             "/src/x/Binary.java",
-            "java_binary",
+            TargetInfoUtilities.javaBinary("com.hello.Binary"),
             "/src/x/SomeTest.java",
-            "java_test",
+            TargetInfoUtilities.javaTest(),
             // AbstractTest is abstract, so must be a java_library.
             "/src/x/AbstractTest.java",
-            "java_library");
+            TargetInfoUtilities.javaLibrary());
   }
 
   private void createSourceFiles(String dir, String... filePaths) throws IOException {

--- a/src/main/java/com/google/devtools/build/bfg/BUILD
+++ b/src/main/java/com/google/devtools/build/bfg/BUILD
@@ -20,6 +20,7 @@ java_library(
         ":BuildRule",
         ":ClassToRuleResolver",
         ":StronglyConnectedComponents",
+        ":bfg_java_proto",
         "//thirdparty/jvm/com/google/guava",
         "//thirdparty/jvm/com/google/re2j",
     ],
@@ -54,6 +55,7 @@ java_library(
     deps = [
         ":BuildozerCommand",
         ":StandardUnionFind",
+        ":bfg_java_proto",
         "//thirdparty/jvm/com/google/auto/value:auto_value",
         "//thirdparty/jvm/com/google/guava",
         "//thirdparty/jvm/com/google/re2j",
@@ -129,5 +131,15 @@ proto_library(
 java_proto_library(
     name = "bfg_java_proto",
     deps = [":bfg_proto"],
+    visibility = ["//visibility:public"],
+)
+
+java_library(
+    name = "TargetInfoUtilities",
+    srcs = ["TargetInfoUtilities.java"],
+    deps = [
+        ":bfg_java_proto",
+        "//thirdparty/jvm/com/google/guava",            
+    ],
     visibility = ["//visibility:public"],
 )

--- a/src/main/java/com/google/devtools/build/bfg/BuildozerCommand.java
+++ b/src/main/java/com/google/devtools/build/bfg/BuildozerCommand.java
@@ -38,4 +38,8 @@ class BuildozerCommand {
   static String addAttribute(String attribute, Iterable<String> values, String target) {
     return String.format("add %s %s|%s", attribute, Joiner.on(" ").join(values), target);
   }
+
+  static String addFragment(String fragment, String target) {
+    return String.format("%s|%s", fragment, target);
+  }
 }

--- a/src/main/java/com/google/devtools/build/bfg/TargetInfoUtilities.java
+++ b/src/main/java/com/google/devtools/build/bfg/TargetInfoUtilities.java
@@ -1,0 +1,42 @@
+package com.google.devtools.build.bfg;
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.nio.file.Path;
+import protos.com.google.devtools.build.bfg.Bfg;
+import protos.com.google.devtools.build.bfg.Bfg.TargetInfo;
+
+public abstract class TargetInfoUtilities {
+
+  public static TargetInfo javaLibrary() {
+    return TargetInfo.newBuilder().setRuleKind("java_library").build();
+  }
+
+  public static TargetInfo javaTest() {
+    return TargetInfo.newBuilder().setRuleKind("java_test").build();
+  }
+
+  public static TargetInfo javaBinary(String mainClass) {
+    return TargetInfo.newBuilder().setRuleKind("java_binary")
+        .setBuildozerCommands(Bfg.Strings.newBuilder().addElements(String.format("set main_class %s", mainClass)).build()).
+            build();
+  }
+
+  public static ImmutableMap<Path, TargetInfo> javaLibraries(Path... paths) {
+    return ImmutableMap.copyOf(Maps.asMap(Sets.newHashSet(paths), p -> javaLibrary()));
+  }
+}

--- a/src/main/java/com/google/devtools/build/bfg/bfg.proto
+++ b/src/main/java/com/google/devtools/build/bfg/bfg.proto
@@ -17,9 +17,17 @@ message ParserOutput {
     // Paths are expected to be absolute.
     map<string, Strings> class_to_file = 2;
 
-    // Maps a file name to the Bazel rule kind (e.g., java_library) that should be used to build it.
-    // Paths are expected to be absolute.
-    map<string, string> file_to_rule_kind = 3;
+    // Maps a file name to the Bazel rule kind (e.g., java_library) and Buildozer command fragments
+    // that should be used to build it. Paths are expected to be absolute.
+    // The buildozer_commands supply all of the info that Bfg will not deduce from the graph of classes and files.
+    // e.g. for a java_binary we need the main class.
+    map<string, TargetInfo> file_to_target_info = 3;
+}
+
+
+message TargetInfo {
+    required string rule_kind = 1;
+    optional Strings buildozer_commands = 2;
 }
 
 message Strings {

--- a/src/test/java/com/google/devtools/build/bfg/BUILD
+++ b/src/test/java/com/google/devtools/build/bfg/BUILD
@@ -7,6 +7,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/bfg:BuildRule",
         "//src/main/java/com/google/devtools/build/bfg:ClassToRuleResolver",
         "//src/main/java/com/google/devtools/build/bfg:GraphProcessor",
+        "//src/main/java/com/google/devtools/build/bfg:TargetInfoUtilities",
         "//thirdparty/jvm/com/google/guava",
         "//thirdparty/jvm/com/google/truth",
         "//thirdparty/jvm/junit",
@@ -31,6 +32,8 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/bfg:BuildRule",
         "//src/main/java/com/google/devtools/build/bfg:BuildozerCommandCreator",
+        "//src/main/java/com/google/devtools/build/bfg:TargetInfoUtilities",
+        "//src/main/java/com/google/devtools/build/bfg:bfg_java_proto",
         "//thirdparty/jvm/com/google/guava",
         "//thirdparty/jvm/com/google/truth",
         "//thirdparty/jvm/junit",
@@ -41,7 +44,9 @@ java_test(
     name = "ProjectBuildRuleTest",
     srcs = ["ProjectBuildRuleTest.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/bfg:bfg_java_proto",
         "//src/main/java/com/google/devtools/build/bfg:BuildRule",
+        "//src/main/java/com/google/devtools/build/bfg:TargetInfoUtilities",
         "//thirdparty/jvm/com/google/guava",
         "//thirdparty/jvm/com/google/truth",
         "//thirdparty/jvm/junit",
@@ -64,8 +69,10 @@ java_test(
     name = "ProjectClassToRuleResolverTest",
     srcs = ["ProjectClassToRuleResolverTest.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/bfg:bfg_java_proto",
         "//src/main/java/com/google/devtools/build/bfg:BuildRule",
         "//src/main/java/com/google/devtools/build/bfg:GraphProcessor",
+        "//src/main/java/com/google/devtools/build/bfg:TargetInfoUtilities",                 
         "//thirdparty/jvm/com/google/guava",
         "//thirdparty/jvm/com/google/jimfs",
         "//thirdparty/jvm/com/google/re2j",
@@ -119,4 +126,3 @@ java_test(
         "//thirdparty/jvm/junit",
     ],
 )
-

--- a/src/test/java/com/google/devtools/build/bfg/BuildozerCommandCreatorTest.java
+++ b/src/test/java/com/google/devtools/build/bfg/BuildozerCommandCreatorTest.java
@@ -21,6 +21,7 @@ import static com.google.devtools.build.bfg.BuildozerCommandCreator.getBuildFile
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
 import java.nio.file.Path;
@@ -171,7 +172,7 @@ public class BuildozerCommandCreatorTest {
     Path packagePath = Paths.get(packagePathStr);
     ImmutableSet<Path> srcFilePaths =
         Arrays.stream(srcFiles).map(src -> packagePath.resolve(src)).collect(toImmutableSet());
-
-    return new ProjectBuildRule(srcFilePaths, packagePath, DEFAULT_WORKSPACE);
+    // For these tests we can assume these are all java_library rules.
+    return new ProjectBuildRule(Maps.toMap(srcFilePaths, p -> TargetInfoUtilities.javaLibrary()), packagePath, DEFAULT_WORKSPACE);
   }
 }

--- a/src/test/java/com/google/devtools/build/bfg/GraphProcessorTest.java
+++ b/src/test/java/com/google/devtools/build/bfg/GraphProcessorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Graph;
 import com.google.common.graph.GraphBuilder;
@@ -218,6 +219,7 @@ public class GraphProcessorTest {
     Path packagePath = WORKSPACE_DEFAULT.resolve(packagePathString);
     Path[] srcFilePaths =
         Arrays.stream(srcFiles).map(srcFile -> packagePath.resolve(srcFile)).toArray(Path[]::new);
-    return new ProjectBuildRule(ImmutableSet.copyOf(srcFilePaths), packagePath, WORKSPACE_DEFAULT);
+    // For these tests we can assume these are all java_library rules.
+    return new ProjectBuildRule(Maps.toMap(ImmutableSet.copyOf(srcFilePaths), p -> TargetInfoUtilities.javaLibrary()), packagePath, WORKSPACE_DEFAULT);
   }
 }


### PR DESCRIPTION
Changes needed to make this pass:
- Returning Buildozer command fragments for certain targets in the language-specific parsers that cannot be deduced by the BFG. E.g.: a main class for a java_binary.
- Adding graph nodes for all targets found to ensure that BUILD files are generated for disconnected targets.
- Generalizing the heuristics for merging different rule kinds within the same strongly connected component.

TODOs
- Should the e2e script be an `sh_test` or implemented natively in Skylark? How will we want it to work if we expand this to tests that use Maven, Gradle, Sbt, etc.?
- Adding e2e tests that use external dependencies.